### PR TITLE
Add missing double-quote

### DIFF
--- a/website/source/docs/job-specification/sidecar_task.html.md
+++ b/website/source/docs/job-specification/sidecar_task.html.md
@@ -70,7 +70,7 @@ The default sidecar task is equivalent to:
 
      driver = "docker"
      config {
-       image = "${meta.connect.sidecar_image}
+       image = "${meta.connect.sidecar_image}"
        args  = [
          "-c",
          "${NOMAD_SECRETS_DIR}/envoy_bootstrap.json",


### PR DESCRIPTION
The missing double-quote was messing with the syntax highlighting. Adding it in.